### PR TITLE
Add methods for public HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ try {
 }
 ```
 
+- `cb`
+
+```javascript
+const callback = (error, data) => {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log(data);
+  }
+};
+publicClient.cb('getLoanOrders', callback, { currency: 'BTC' });
+```
+
 - `request`
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ publicClient
   });
 ```
 
+- [`getOrderBook`](https://docs.poloniex.com/?shell#returnorderbook)
+
+```javascript
+publicClient
+  .getOrderBook({ currencyPair: 'USDT_BTC', depth: 25 })
+  .then(data => {
+    console.log(data);
+  })
+  .catch(error => {
+    console.error(error);
+  });
+```
+
 - `get`
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -17,11 +17,24 @@ const Poloniex = require('poloniex-node-api');
 const publicClient = new Poloniex.PublicClient();
 ```
 
-- `getTickers`
+- [`getTickers`](https://docs.poloniex.com/?shell#returnticker)
 
 ```javascript
 publicClient
   .getTickers()
+  .then(data => {
+    console.log(data);
+  })
+  .catch(error => {
+    console.error(error);
+  });
+```
+
+- [`getVolume`](https://docs.poloniex.com/?shell#return24hvolume)
+
+```javascript
+publicClient
+  .getVolume()
   .then(data => {
     console.log(data);
   })

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ publicClient
   });
 ```
 
+- [`getCurrencies`](https://docs.poloniex.com/?shell#returnchartdata)
+
+```javascript
+try {
+  const currencies = await publicClient.getCurrencies();
+  console.log(currencies);
+} catch (error) {
+  console.error(error);
+}
+```
+
 - `get`
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ const Poloniex = require('poloniex-node-api');
 const publicClient = new Poloniex.PublicClient();
 ```
 
+- `getTickers`
+
+```javascript
+publicClient
+  .getTickers()
+  .then(data => {
+    console.log(data);
+  })
+  .catch(error => {
+    console.error(error);
+  });
+```
+
 - `get`
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ publicClient
   });
 ```
 
+- [`getTradeHistory`](https://docs.poloniex.com/?shell#returntradehistory-public)
+
+```javascript
+publicClient
+  .getTradeHistory({
+    currencyPair: 'USDT_BTC',
+    start: 1410158341,
+    end: 1410499372,
+  })
+  .then(data => {
+    console.log(data);
+  })
+  .catch(error => {
+    console.error(error);
+  });
+```
+
 - `get`
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ publicClient
   });
 ```
 
-- [`getCurrencies`](https://docs.poloniex.com/?shell#returnchartdata)
+- [`getCurrencies`](https://docs.poloniex.com/?shell#returncurrencies)
 
 ```javascript
 try {
@@ -102,17 +102,15 @@ try {
 }
 ```
 
-- `get`
+- [`getLoanOrders`](https://docs.poloniex.com/?shell#returnloanorders)
 
 ```javascript
-publicClient
-  .get({ command: 'returnCurrencies' })
-  .then(data => {
-    console.log(data);
-  })
-  .catch(error => {
-    console.error(error);
-  });
+try {
+  const loans = await publicClient.getLoanOrders({ currency: 'USDT' });
+  console.log(currencies);
+} catch (error) {
+  console.error(error);
+}
 ```
 
 - `request`

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ publicClient
   });
 ```
 
+- [`getChartData`](https://docs.poloniex.com/?shell#returnchartdata)
+
+```javascript
+publicClient
+  .getChartData({
+    currencyPair: 'BTC_XMR',
+    period: 14400,
+    start: 1546300800,
+    end: 1546646400,
+  })
+  .then(data => {
+    console.log(data);
+  })
+  .catch(error => {
+    console.error(error);
+  });
+```
+
 - `get`
 
 ```javascript

--- a/lib/public.js
+++ b/lib/public.js
@@ -78,6 +78,16 @@ class PublicClient {
   }
 
   /**
+   * @example
+   * const tickers = await publicClient.getTickers();
+   * @description Retrieves summary information for each currency pair listed on the exchange.
+   * @see {@link https://docs.poloniex.com/?shell#returnticker|returnTicker}
+   */
+  getTickers() {
+    return this.get({ command: 'returnTicker' });
+  }
+
+  /**
    * @private
    * @param {...*} [properties]
    * @example

--- a/lib/public.js
+++ b/lib/public.js
@@ -88,6 +88,16 @@ class PublicClient {
   }
 
   /**
+   * @example
+   * const volume = await publicClient.getVolume();
+   * @description Retrieves the 24-hour volume for all markets as well as totals for primary currencies.
+   * @see {@link https://docs.poloniex.com/?shell#return24hvolume|return24hVolume}
+   */
+  getVolume() {
+    return this.get({ command: 'return24hVolume' });
+  }
+
+  /**
    * @private
    * @param {...*} [properties]
    * @example

--- a/lib/public.js
+++ b/lib/public.js
@@ -3,22 +3,25 @@ const {
   EXCHANGE_API_URL,
   DEFAULT_TIMEOUT,
   API_LIMIT,
+  DEFAULT_PAIR,
   HEADERS,
 } = require('./utilities');
 
 class PublicClient {
   /**
    * @param {Object} [options={}]
+   * @param {string} [options.currencyPair] - If `currencyPair` is provided then it will be used in all future requests that require `currencyPair` but it is omitted (not applied to requests where `currencyPair` is optional).
    * @param {string} [options.api_uri] - Overrides the default apiuri, if provided.
    * @param {number} [options.timeout] - Overrides the default timeout, if provided.
    * @example
    * const Poloniex = require('poloniex-node-api');
-   * const publicClient = new Poloniex.PublicClient();
+   * const publicClient = new Poloniex.PublicClient({ currencyPair: 'BTC_ETH' });
    * @description Create PublicClient.
    */
-  constructor({ api_uri = EXCHANGE_API_URL, timeout = DEFAULT_TIMEOUT } = {}) {
-    this.api_uri = api_uri;
-    this.timeout = timeout;
+  constructor({ currencyPair, api_uri, timeout } = {}) {
+    this.currencyPair = currencyPair || DEFAULT_PAIR;
+    this.apiURI = api_uri ? api_uri : EXCHANGE_API_URL;
+    this.timeout = timeout || DEFAULT_TIMEOUT;
   }
 
   /**
@@ -116,6 +119,29 @@ class PublicClient {
    */
   getOrderBook({ currencyPair = 'all', depth = API_LIMIT } = {}) {
     return this.get({ command: 'returnOrderBook', currencyPair, depth });
+  }
+
+  /**
+   * @param {Object} [options]
+   * @param {string} [options.currencyPair] - If `currencyPair` is not provided then the default currencyPair will be used.
+   * @param {number} [options.start] - UNIX timestamp.
+   * @param {number} [options.end] - UNIX timestamp.
+   * @example
+   * const history = await publicClient.getTradeHistory({
+   *   currencyPair: 'USDT_ZEC',
+   *   start: 1410158328,
+   *   end: 1410488343,
+   * });
+   * @see {@link https://docs.poloniex.com/?shell#returntradehistory-public|returnTradeHistory}
+   * @description Get the past 200 trades for a given market, or up to 1,000 trades between a range `start` and `end`.
+   */
+  getTradeHistory({ currencyPair = this.currencyPair, start, end } = {}) {
+    return this.get({
+      command: 'returnTradeHistory',
+      currencyPair,
+      start,
+      end,
+    });
   }
 
   /**

--- a/lib/public.js
+++ b/lib/public.js
@@ -1,5 +1,10 @@
 const request = require('request-promise');
-const { EXCHANGE_API_URL, DEFAULT_TIMEOUT, HEADERS } = require('./utilities');
+const {
+  EXCHANGE_API_URL,
+  DEFAULT_TIMEOUT,
+  API_LIMIT,
+  HEADERS,
+} = require('./utilities');
 
 class PublicClient {
   /**
@@ -95,6 +100,22 @@ class PublicClient {
    */
   getVolume() {
     return this.get({ command: 'return24hVolume' });
+  }
+
+  /**
+   * @param {Object} [options]
+   * @param {string} [options.currencyPair='all'] - A pair like `BTC_ETH` or `all`.
+   * @param {number} [options.depth] - Max depth is `100`.
+   * @example
+   * const book = await publicClient.getOrderBook({
+   *   depth: 25,
+   *   currencyPair: 'USDT_ZEC',
+   * });
+   * @see {@link https://docs.poloniex.com/?shell#returnorderbook|returnOrderBook}
+   * @description Get chat messages.
+   */
+  getOrderBook({ currencyPair = 'all', depth = API_LIMIT } = {}) {
+    return this.get({ command: 'returnOrderBook', currencyPair, depth });
   }
 
   /**

--- a/lib/public.js
+++ b/lib/public.js
@@ -173,6 +173,16 @@ class PublicClient {
   }
 
   /**
+   * @example
+   * const currencies = await publicClient.getCurrencies();
+   * @see {@link https://docs.poloniex.com/?shell#returncurrencies|returnCurrencies}
+   * @description Get information about currencies.
+   */
+  getCurrencies() {
+    return this.get({ command: 'returnCurrencies' });
+  }
+
+  /**
    * @private
    * @param {...*} [properties]
    * @example

--- a/lib/public.js
+++ b/lib/public.js
@@ -20,7 +20,7 @@ class PublicClient {
    */
   constructor({ currencyPair, api_uri, timeout } = {}) {
     this.currencyPair = currencyPair || DEFAULT_PAIR;
-    this.apiURI = api_uri ? api_uri : EXCHANGE_API_URL;
+    this.api_uri = api_uri ? api_uri : EXCHANGE_API_URL;
     this.timeout = timeout || DEFAULT_TIMEOUT;
   }
 
@@ -84,6 +84,17 @@ class PublicClient {
         })
         .catch(error => reject(error));
     });
+  }
+
+  cb(method, callback, options) {
+    try {
+      this[method]
+        .call(this, options)
+        .then(data => callback(null, data))
+        .catch(error => callback(error));
+    } catch (error) {
+      callback(error);
+    }
   }
 
   /**

--- a/lib/public.js
+++ b/lib/public.js
@@ -25,6 +25,7 @@ class PublicClient {
   }
 
   /**
+   * @private
    * @param {Object} options
    * @param {string} options.command
    * @example
@@ -180,6 +181,20 @@ class PublicClient {
    */
   getCurrencies() {
     return this.get({ command: 'returnCurrencies' });
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.currency
+   * @example
+   * const loans = publicClient.getLoanOrders({ currency: 'BTC' });
+   * @see {@link https://docs.poloniex.com/?shell#returnloanorders|returnLoanOrders}
+   * @description Get the list of loan offers and demands for a given currency.
+   */
+  getLoanOrders({ currency } = {}) {
+    this._requireProperties(currency);
+
+    return this.get({ command: 'returnLoanOrders', currency });
   }
 
   /**

--- a/lib/public.js
+++ b/lib/public.js
@@ -145,6 +145,34 @@ class PublicClient {
   }
 
   /**
+   * @param {Object} options
+   * @param {string} [options.currencyPair] - If `currencyPair` is not provided then the default currencyPair will be used.
+   * @param {number} options.period - Candlestick period in seconds. Valid values are 300, 900, 1800, 7200, 14400, and 86400.
+   * @param {number} options.start - UNIX timestamp.
+   * @param {number} options.end - UNIX timestamp.
+   * @example
+   * const publicClient = new Poloniex.PublicClient({ currencyPair: 'BTC_DASH' });
+   * const candles = await publicClient.getChartData({
+   *   start: 1546300800,
+   *   end: 1546646400,
+   *   period: 14400,
+   * });
+   * @see {@link https://docs.poloniex.com/?shell#returnchartdata|returnChartData}
+   * @description Get candlestick chart data.
+   */
+  getChartData({ currencyPair = this.currencyPair, period, start, end } = {}) {
+    this._requireProperties(period, start, end);
+
+    return this.get({
+      command: 'returnChartData',
+      currencyPair,
+      period,
+      start,
+      end,
+    });
+  }
+
+  /**
    * @private
    * @param {...*} [properties]
    * @example

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,4 +1,5 @@
 const DEFAULT_TIMEOUT = 10000;
+const API_LIMIT = 100;
 const EXCHANGE_API_URL = 'https://poloniex.com';
 const HEADERS = {
   'User-Agent': 'poloniex-node-api-client',
@@ -7,4 +8,4 @@ const HEADERS = {
   'X-Requested-With': 'XMLHttpRequest',
 };
 
-module.exports = { DEFAULT_TIMEOUT, EXCHANGE_API_URL, HEADERS };
+module.exports = { API_LIMIT, DEFAULT_TIMEOUT, EXCHANGE_API_URL, HEADERS };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,5 +1,6 @@
 const DEFAULT_TIMEOUT = 10000;
 const API_LIMIT = 100;
+const DEFAULT_PAIR = 'USDT_BTC';
 const EXCHANGE_API_URL = 'https://poloniex.com';
 const HEADERS = {
   'User-Agent': 'poloniex-node-api-client',
@@ -8,4 +9,10 @@ const HEADERS = {
   'X-Requested-With': 'XMLHttpRequest',
 };
 
-module.exports = { API_LIMIT, DEFAULT_TIMEOUT, EXCHANGE_API_URL, HEADERS };
+module.exports = {
+  API_LIMIT,
+  DEFAULT_PAIR,
+  DEFAULT_TIMEOUT,
+  EXCHANGE_API_URL,
+  HEADERS,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "poloniex-node-api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poloniex-node-api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Poloniex Node.js API",
   "main": "index.js",
   "directories": {

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -82,4 +82,26 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getVolume()', done => {
+    const volume = {
+      USDT_BTC: { USDT: '7161846.98235853', BTC: '790.32984132' },
+      USDT_ETH: { USDT: '895368.56029939', ETH: '3331.80491546' },
+      totalETH: '370.77305935',
+      totalBTC: '1845.83395826',
+      totalUSDT: '11287088.18195494',
+    };
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=return24hVolume')
+      .times(1)
+      .reply(200, volume);
+
+    publicClient
+      .getVolume()
+      .then(data => {
+        assert.deepEqual(data, volume);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -42,6 +42,33 @@ suite('PublicClient', () => {
       });
   });
 
+  test('.cb()', () => {
+    const response = { response: 1 };
+    const options = { method: 'GET', url: EXCHANGE_API_URL + '/public' };
+    nock(EXCHANGE_API_URL)
+      .get('/public')
+      .times(2)
+      .reply(200, response);
+
+    const cbreq = new Promise((resolve, reject) => {
+      const callback = (error, data) => {
+        if (error) {
+          reject(error);
+        } else {
+          assert.deepEqual(data, response);
+          resolve(data);
+        }
+      };
+      publicClient.cb('request', callback, options);
+    });
+
+    const preq = publicClient
+      .request(options)
+      .then(data => assert.deepEqual(data, response))
+      .catch(error => assert.fail(error));
+    return Promise.all([cbreq, preq]);
+  });
+
   test('.getTickers()', done => {
     const tickers = {
       USDT_BTC: {

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -163,4 +163,93 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getTradeHistory()', done => {
+    const trades = [
+      {
+        globalTradeID: 420170516,
+        tradeID: 27129920,
+        date: '2019-06-17 15:25:18',
+        type: 'buy',
+        rate: '9257.23051444',
+        amount: '0.01394711',
+        total: '129.11161228',
+        orderNumber: 277619132092,
+      },
+      {
+        globalTradeID: 420170477,
+        tradeID: 27129919,
+        date: '2019-06-17 15:24:19',
+        type: 'sell',
+        rate: '9257.18336240',
+        amount: '0.07792262',
+        total: '721.34398141',
+        orderNumber: 277619040184,
+      },
+      {
+        globalTradeID: 420170476,
+        tradeID: 27129918,
+        date: '2019-06-17 15:24:18',
+        type: 'sell',
+        rate: '9257.18336240',
+        amount: '0.00259138',
+        total: '23.98887982',
+        orderNumber: 277619039185,
+      },
+    ];
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=returnTradeHistory&currencyPair=USDT_BTC')
+      .times(1)
+      .reply(200, trades);
+
+    publicClient
+      .getTradeHistory()
+      .then(data => {
+        assert.deepEqual(data, trades);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getTradeHistory() (with parameters)', done => {
+    const options = { start: 1560783670, end: 1560783719 };
+    const trades = [
+      {
+        globalTradeID: 420168521,
+        tradeID: 47110335,
+        date: '2019-06-17 15:01:58',
+        type: 'sell',
+        rate: '0.02924282',
+        amount: '0.32220457',
+        total: '0.00942217',
+        orderNumber: 605151881509,
+      },
+      {
+        globalTradeID: 420168418,
+        tradeID: 47110334,
+        date: '2019-06-17 15:01:10',
+        type: 'sell',
+        rate: '0.02925860',
+        amount: '1.00000000',
+        total: '0.02925860',
+        orderNumber: 605151487903,
+      },
+    ];
+    nock(EXCHANGE_API_URL)
+      .get(
+        '/public?command=returnTradeHistory&currencyPair=BTC_ETH&start=1560783670&end=1560783719'
+      )
+      .times(1)
+      .reply(200, trades);
+
+    const client = new Poloniex.PublicClient({ currencyPair: 'BTC_ETH' });
+
+    client
+      .getTradeHistory(options)
+      .then(data => {
+        assert.deepEqual(data, trades);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -104,4 +104,63 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getOrderBook()', done => {
+    const book = {
+      USDT_BTC: {
+        asks: [['9297.44488770', 0.143181], ['9298.08427869', 0.0001161]],
+        bids: [['9297.24540399', 1.46374898], ['9297.24540398', 0.0443]],
+        isFrozen: '0',
+        seq: 376097564,
+      },
+      BTC_ETH: {
+        asks: [['0.02930568', 0.56225405], ['0.02931998', 1]],
+        bids: [['0.02930505', 0.00011779], ['0.02929320', 25]],
+        isFrozen: '0',
+        seq: 711985070,
+      },
+    };
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=returnOrderBook&currencyPair=all&depth=100')
+      .times(1)
+      .reply(200, book);
+
+    publicClient
+      .getOrderBook()
+      .then(data => {
+        assert.deepEqual(data, book);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getOrderBook() (with parameters)', done => {
+    const book = {
+      asks: [
+        ['135.58999999', 7.90480727],
+        ['135.59000000', 3.04610694],
+        ['135.59662720', 0.00883215],
+      ],
+      bids: [
+        ['134.72221617', 1.3],
+        ['134.72221012', 12.4],
+        ['134.72220998', 90.22],
+      ],
+      isFrozen: '0',
+      seq: 295173803,
+    };
+    const options = { currencyPair: 'USDT_LTC', depth: 3 };
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=returnOrderBook&currencyPair=USDT_LTC&depth=3')
+      .times(1)
+      .reply(200, book);
+
+    publicClient
+      .getOrderBook(options)
+      .then(data => {
+        assert.deepEqual(data, book);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -252,4 +252,58 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getChartData()', done => {
+    const candles = [
+      {
+        date: 1560613059,
+        high: 8809.26970927,
+        low: 8809.26970927,
+        open: 8809.26970927,
+        close: 8809.26970927,
+        volume: 0,
+        quoteVolume: 0,
+        weightedAverage: 8809.26970927,
+      },
+      {
+        date: 1560643200,
+        high: 9325,
+        low: 8759.37683497,
+        open: 8809.49125799,
+        close: 8968.92286817,
+        volume: 11929575.934481,
+        quoteVolume: 1317.2708549,
+        weightedAverage: 9056.28169795,
+      },
+      {
+        date: 1560729600,
+        high: 9390.83903896,
+        low: 8949.00000001,
+        open: 8963.50269782,
+        close: 9157.79085762,
+        volume: 3895287.1624447,
+        quoteVolume: 423.63287478,
+        weightedAverage: 9194.95958491,
+      },
+    ];
+    const options = {
+      period: 86400,
+      start: 1560613059,
+      end: 1560785858,
+    };
+    nock(EXCHANGE_API_URL)
+      .get(
+        '/public?command=returnChartData&currencyPair=USDT_BTC&period=86400&start=1560613059&end=1560785858'
+      )
+      .times(1)
+      .reply(200, candles);
+
+    publicClient
+      .getChartData(options)
+      .then(data => {
+        assert.deepEqual(data, candles);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -41,4 +41,45 @@ suite('PublicClient', () => {
         done();
       });
   });
+
+  test('.getTickers()', done => {
+    const tickers = {
+      USDT_BTC: {
+        id: 121,
+        last: '9162.76459012',
+        lowestAsk: '9162.76459012',
+        highestBid: '9151.76341041',
+        percentChange: '0.04079405',
+        baseVolume: '9649722.16546198',
+        quoteVolume: '1064.67078796',
+        isFrozen: '0',
+        high24hr: '9325.00000000',
+        low24hr: '8732.23922667',
+      },
+      BTC_ETH: {
+        id: 148,
+        last: '0.02963883',
+        lowestAsk: '0.02963878',
+        highestBid: '0.02963850',
+        percentChange: '-0.02552059',
+        baseVolume: '255.46245681',
+        quoteVolume: '8544.98856973',
+        isFrozen: '0',
+        high24hr: '0.03079000',
+        low24hr: '0.02938000',
+      },
+    };
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=returnTicker')
+      .times(1)
+      .reply(200, tickers);
+
+    publicClient
+      .getTickers()
+      .then(data => {
+        assert.deepEqual(data, tickers);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -306,4 +306,47 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getCurrencies()', done => {
+    const currencies = {
+      BTC: {
+        id: 28,
+        name: 'Bitcoin',
+        humanType: 'BTC Clone',
+        currencyType: 'address',
+        txFee: '0.00050000',
+        minConf: 1,
+        depositAddress: null,
+        disabled: 0,
+        delisted: 0,
+        frozen: 0,
+        isGeofenced: 0,
+      },
+      USDT: {
+        id: 214,
+        name: 'Tether USD',
+        humanType: 'Sweep to Main Account',
+        currencyType: 'address',
+        txFee: '10.00000000',
+        minConf: 2,
+        depositAddress: null,
+        disabled: 0,
+        delisted: 0,
+        frozen: 0,
+        isGeofenced: 0,
+      },
+    };
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=returnCurrencies')
+      .times(1)
+      .reply(200, currencies);
+
+    publicClient
+      .getCurrencies()
+      .then(data => {
+        assert.deepEqual(data, currencies);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -349,4 +349,30 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getLoanOrders()', done => {
+    const options = { currency: 'BTC' };
+    const loans = {
+      offers: [
+        { rate: '0.00005900', amount: '0.01961918', rangeMin: 2, rangeMax: 2 },
+        { rate: '0.00006000', amount: '62.24928418', rangeMin: 2, rangeMax: 2 },
+      ],
+      demands: [
+        { rate: '0.02000000', amount: '0.00100014', rangeMin: 2, rangeMax: 2 },
+        { rate: '0.00001000', amount: '0.04190154', rangeMin: 2, rangeMax: 2 },
+      ],
+    };
+    nock(EXCHANGE_API_URL)
+      .get('/public?command=returnLoanOrders&currency=BTC')
+      .times(1)
+      .reply(200, loans);
+
+    publicClient
+      .getLoanOrders(options)
+      .then(data => {
+        assert.deepEqual(data, loans);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });


### PR DESCRIPTION
## Changes
- Add `getTickers` method
- Add `getVolume` method
- Add `getOrderBook` method
- Add `getTradeHistory` method
- Add `getChartData` method
- Add `getCurrencies` method
- Add `getLoanOrders` method
- Add `cb` method to support callbacks in the requests.
- Update tests.
- Update `README`.