### PR TITLE
Add getOrderTrades method

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,8 @@ const balances = await AuthenticatedClient.getBalances();
 - [`getCompleteBalances`](https://docs.poloniex.com/?shell#returncompletebalances)
 
 ```javascript
-const balances = await AuthenticatedClient.getCompleteBalances({
-  account: 'all',
-});
+const account = 'all';
+const balances = await AuthenticatedClient.getCompleteBalances({ account });
 ```
 
 - [`getDepositAddresses`](https://docs.poloniex.com/?shell#returndepositaddresses)
@@ -192,17 +191,22 @@ const deposits_withdrawals = await AuthenticatedClient.getDepositsWithdrawals({
 - [`getOpenOrders`](https://docs.poloniex.com/?shell#returnopenorders)
 
 ```javascript
-const orders = await AuthenticatedClient.getOpenOrders({
-  currencyPair: 'BTC_DASH',
-});
+const currencyPair = 'BTC_DASH';
+const orders = await AuthenticatedClient.getOpenOrders({ currencyPair });
 ```
 
 - [`getHistoryTrades`](https://docs.poloniex.com/?shell#returntradehistory-private)
 
 ```javascript
-const trades = await AuthenticatedClient.getHistoryTrades({
-  currencyPair: 'BTC_ETC',
-});
+const currencyPair = 'BTC_ETC';
+const trades = await AuthenticatedClient.getHistoryTrades({ currencyPair });
+```
+
+- [`getOrderTrades`](https://docs.poloniex.com/?shell#returntradehistory-private)
+
+```javascript
+const orderNumber = 96238912842;
+const trades = await AuthenticatedClient.getOrderTrades({ orderNumber });
 ```
 
 - `post`

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,10 @@ declare module 'poloniex' {
     currency: string;
   };
 
+  export type OrderFilter = {
+    orderNumber: number;
+  };
+
   export type Balances = {
     [currency: string]: string;
   };
@@ -225,6 +229,18 @@ declare module 'poloniex' {
     fee: string;
     category: 'exchange' | 'margin';
   } & Trade;
+
+  export type OrderTrades = {
+    globalTradeID: number;
+    tradeID: number;
+    currencyPair: string;
+    type: 'buy' | 'sell';
+    rate: string;
+    amount: string;
+    total: string;
+    fee: string;
+    date: string;
+  };
 
   export type WsRawMessage = Array<any>;
 
@@ -385,6 +401,8 @@ declare module 'poloniex' {
     getOpenOrders(options?: CurrencyPairFilter): Promise<Orders>;
 
     getHistoryTrades(options?: CurrencyPairFilter): Promise<TradePrivate[]>;
+
+    getOrderTrades(options: OrderFilter): Promise<OrderTrades[]>;
   }
 
   export class WebsocketClient extends EventEmitter {

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -151,6 +151,19 @@ class AuthenticatedClient extends PublicClient {
   }
 
   /**
+   * @param {Object} [options]
+   * @param {string} [options.orderNumber] - The order number whose trades you wish to query.
+   * @example
+   * const trades = AuthenticatedClient.getOrderTrades({ orderNumber: 96238912841 });
+   * @description Get all trades involving a given order.
+   * @see {@link https://docs.poloniex.com/?shell#returntradehistory-private|returnOrderTrades}
+   */
+  getOrderTrades({ orderNumber } = {}) {
+    this._requireProperties(orderNumber);
+    return this.post({ command: 'returnOrderTrades', orderNumber });
+  }
+
+  /**
    * @private
    * @example
    * const nonce = AuthenticatedClient._nonce();

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -278,4 +278,47 @@ suite('AuthenticatedClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getOrderTrades()', done => {
+    const trades = [
+      {
+        globalTradeID: 394127362,
+        tradeID: 13536351,
+        currencyPair: 'BTC_STR',
+        type: 'buy',
+        rate: '0.00003432',
+        amount: '3696.05342780',
+        total: '0.12684855',
+        fee: '0.00200000',
+        date: '2018-10-16 17:03:43',
+      },
+      {
+        globalTradeID: 394127361,
+        tradeID: 13536350,
+        currencyPair: 'BTC_STR',
+        type: 'buy',
+        rate: '0.00003432',
+        amount: '3600.53748129',
+        total: '0.12357044',
+        fee: '0.00200000',
+        date: '2018-10-16 17:03:43',
+      },
+    ];
+    const orderNumber = 9623891284;
+    const nonce = 154264078495300;
+    authClient.nonce = () => nonce;
+
+    nock(EXCHANGE_API_URL)
+      .post('/tradingApi', { command: 'returnOrderTrades', orderNumber, nonce })
+      .times(1)
+      .reply(200, trades);
+
+    authClient
+      .getOrderTrades({ orderNumber })
+      .then(data => {
+        assert.deepEqual(data, trades);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });


### PR DESCRIPTION
### AuthenticatedClient
 - https://github.com/vansergen/poloniex-node-api/commit/d33f87cf039cb8599a10c498e59df27cff5a1bd2 Add `getOrderTrades` method

#### Other changes
- https://github.com/vansergen/poloniex-node-api/commit/9edad64a7653a6377773889dad3f986623cd4e74 Update tests
- https://github.com/vansergen/poloniex-node-api/commit/53e995a4d8fe97dc3aa45d3ef3a3323fdc4e63db Update `README`
- https://github.com/vansergen/poloniex-node-api/commit/393cbb3c9f130a9601dcbb2f670d60423d40de93 Update `Typescript` definitions