### PR TITLE
Fix: Reject unsuccessful requests

### DIFF
--- a/lib/public.js
+++ b/lib/public.js
@@ -79,6 +79,8 @@ class PublicClient {
         .then(data => {
           if (data.error) {
             reject(data.error);
+          } else if (!data.success && data.result && data.result.error) {
+            reject(data.result.error);
           } else {
             resolve(data);
           }


### PR DESCRIPTION
#### Example
Requests with `success: 0`:
```js
{ success: 0, result: { error: 'Order not found.' } }
```
will reject a promise.