### PR TITLE
Add cancelOrder method

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,13 @@ const amount = 1;
 const order = await AuthenticatedClient.sell({ currencyPair, rate, amount });
 ```
 
+- [`cancelOrder`](https://docs.poloniex.com/?shell#cancelorder)
+
+```javascript
+const orderNumber = 514845991795;
+const order = await AuthenticatedClient.cancelOrder({ orderNumber });
+```
+
 - `post`
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -276,6 +276,14 @@ declare module 'poloniex' {
     currencyPair: string;
   };
 
+  export type CancelResponse = {
+    success: 0 | 1;
+    amount: string;
+    message: string;
+    fee?: string;
+    currencyPair?: string;
+  };
+
   export type WsRawMessage = Array<any>;
 
   export namespace WebsocketMessage {
@@ -443,6 +451,8 @@ declare module 'poloniex' {
     buy(options: OrderOptions): Promise<OrderResult>;
 
     sell(options: OrderOptions): Promise<OrderResult>;
+
+    cancelOrder(options: OrderFilter): Promise<CancelResponse>;
   }
 
   export class WebsocketClient extends EventEmitter {

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -188,7 +188,7 @@ class AuthenticatedClient extends PublicClient {
    * const currencyPair = 'BTC_ETH';
    * const rate = 0.01;
    * const amount = 1;
-   * const buy = AuthenticatedClient.buy({ currencyPair, rate, amount });
+   * const order = AuthenticatedClient.buy({ currencyPair, rate, amount });
    * @description Places a limit buy order.
    * @see {@link https://docs.poloniex.com/?shell#buy|buy}
    */
@@ -224,7 +224,7 @@ class AuthenticatedClient extends PublicClient {
    * const currencyPair = 'BTC_ETH';
    * const rate = 0.01;
    * const amount = 1;
-   * const buy = AuthenticatedClient.sell({ currencyPair, rate, amount });
+   * const order = AuthenticatedClient.sell({ currencyPair, rate, amount });
    * @description Places a limit sell order.
    * @see {@link https://docs.poloniex.com/?shell#sell|sell}
    */
@@ -246,6 +246,19 @@ class AuthenticatedClient extends PublicClient {
       immediateOrCancel,
       postOnly,
     });
+  }
+
+  /**
+   * @param {Object} [options]
+   * @param {string} [options.orderNumber] - The identity number of the order to be canceled.
+   * @example
+   * const order = AuthenticatedClient.cancelOrder({ orderNumber: 514845991795 });
+   * @description Cancel an order you have placed in a given market.
+   * @see {@link https://docs.poloniex.com/?shell#cancelorder|cancelOrder}
+   */
+  cancelOrder({ orderNumber } = {}) {
+    this._requireProperties(orderNumber);
+    return this.post({ command: 'cancelOrder', orderNumber });
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "poloniex-node-api",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -818,9 +818,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poloniex-node-api",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Poloniex Node.js API",
   "main": "index.js",
   "directories": {

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -487,4 +487,28 @@ suite('AuthenticatedClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.cancelOrder()', done => {
+    const result = {
+      success: 1,
+      amount: '50.00000000',
+      message: 'Order #514845991795 canceled.',
+    };
+    const orderNumber = 514845991795;
+    const nonce = 154264078495300;
+    authClient.nonce = () => nonce;
+
+    nock(EXCHANGE_API_URL)
+      .post('/tradingApi', { command: 'cancelOrder', orderNumber, nonce })
+      .times(1)
+      .reply(200, result);
+
+    authClient
+      .cancelOrder({ orderNumber })
+      .then(data => {
+        assert.deepEqual(data, result);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });


### PR DESCRIPTION
### AuthenticatedClient
 - https://github.com/vansergen/poloniex-node-api/commit/b3e088ef1722a2326994be975a9a36f0f753da15 Add `cancelOrder` method

#### Other changes
- https://github.com/vansergen/poloniex-node-api/commit/f943eca13a336f9d36c1b0c7cd95c64548130423 Update tests
- https://github.com/vansergen/poloniex-node-api/commit/17f3d45e44f56759775c785b4b142411af2430a6 Update `README`
- https://github.com/vansergen/poloniex-node-api/commit/380c18ae8c3332f05529435333a8ffe8a8aaceb9 Update `Typescript` definitions
- https://github.com/vansergen/poloniex-node-api/commit/525ec9ceb47156410a188d8bb8726350749a030e Update `npm` version