### PR TITLE
Add getMarginAccountSummary method

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,12 @@ const transfer = AuthenticatedClient.transferBalance({
 });
 ```
 
+- [`getMarginAccountSummary`](https://docs.poloniex.com/?shell#returnmarginaccountsummary)
+
+```javascript
+const summary = await AuthenticatedClient.getMarginAccountSummary();
+```
+
 - `post`
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -351,6 +351,15 @@ declare module 'poloniex' {
     message: string;
   };
 
+  export type MarginAccountSummary = {
+    totalValue: string;
+    pl: string;
+    lendingFees: string;
+    netValue: string;
+    totalBorrowedValue: string;
+    currentMargin: string;
+  };
+
   export type WsRawMessage = Array<any>;
 
   export namespace WebsocketMessage {
@@ -536,6 +545,8 @@ declare module 'poloniex' {
     getTradableBalances(): Promise<TradableBalances>;
 
     transferBalance(options: TransferOptions): Promise<TransferResponse>;
+
+    getMarginAccountSummary(): Promise<MarginAccountSummary>;
   }
 
   export class WebsocketClient extends EventEmitter {

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -8,6 +8,7 @@ class AuthenticatedClient extends PublicClient {
    * @param {boolean} options.secret - The Secret.
    * @param {string} [options.api_uri] - Overrides the default apiuri, if provided.
    * @param {number} [options.timeout] - Overrides the default timeout, if provided.
+   * @param {string} [options.currencyPair] - If `currencyPair` is provided then it will be used in all future requests that require `currencyPair` but it is omitted (not applied to requests where `currencyPair` is optional).
    * @throws Will throw an error if incomplete authentication credentials are provided.
    * @example
    * const Poloniex = require('poloniex-node-api');
@@ -403,6 +404,16 @@ class AuthenticatedClient extends PublicClient {
       fromAccount,
       toAccount,
     });
+  }
+
+  /**
+   * @example
+   * const summary = AuthenticatedClient.getMarginAccountSummary();
+   * @see {@link https://docs.poloniex.com/?shell#returnmarginaccountsummary|returnMarginAccountSummary}
+   * @description Get a summary of your entire margin account.
+   */
+  getMarginAccountSummary() {
+    return this.post({ command: 'returnMarginAccountSummary' });
   }
 
   /**

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -700,7 +700,33 @@ suite('AuthenticatedClient', () => {
       .reply(200, result);
 
     authClient
-      .transferBalance({ currency, amount, fromAccount, toAccount, nonce })
+      .transferBalance({ currency, amount, fromAccount, toAccount })
+      .then(data => {
+        assert.deepEqual(data, result);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getMarginAccountSummary()', done => {
+    const result = {
+      totalValue: '0.09999999',
+      pl: '0.00000000',
+      lendingFees: '0.00000000',
+      netValue: '0.09999999',
+      totalBorrowedValue: '0.02534580',
+      currentMargin: '3.94542646',
+    };
+    const nonce = 154264078495300;
+    authClient.nonce = () => nonce;
+
+    nock(EXCHANGE_API_URL)
+      .post('/tradingApi', { command: 'returnMarginAccountSummary', nonce })
+      .times(1)
+      .reply(200, result);
+
+    authClient
+      .getMarginAccountSummary()
       .then(data => {
         assert.deepEqual(data, result);
         done();


### PR DESCRIPTION
### AuthenticatedClient
 - https://github.com/vansergen/poloniex-node-api/commit/2ba1d753de25629d53ea8f6a43f79a0a4a4ea5bf Add `getMarginAccountSummary` method

#### Other changes
- https://github.com/vansergen/poloniex-node-api/commit/fd63e65a8369f77ab3a610285d065cdb89af01c0 Update tests
- https://github.com/vansergen/poloniex-node-api/commit/2c63a7c1625722c8c2c7cf6c58dd3495146b9074 Update `README`
- https://github.com/vansergen/poloniex-node-api/commit/c716d0136735d742ae925337abbd1f29f711ce88 Update `Typescript` definitions